### PR TITLE
GraphQL (Apollo): Improves the example, fixes initial request interception

### DIFF
--- a/examples/graphql-react-apollo/README.md
+++ b/examples/graphql-react-apollo/README.md
@@ -42,7 +42,14 @@ $ yarn test:e2e
 ## Key points
 
 - [`src/mocks.js`](src/mocks.js) describes GraphQL operations to mock.
+
+### Browser
+
 - [`src/index.js`](src/index.js) conditionally enables mocking in `development` environment.
-- [`src/setupTests.js`](src/setupTests.js) enables mocking for unit tests via `beforeAll`/`afterAll` hooks.
+- [`src/ApolloClient.js`](src/ApolloClient.js) uses an explicit `fetch` reference in order for requests to be captured and deferred until the Service Worker is ready. Necessary due to Apollo hoisting a native `window.fetch` call, preventing Mock Service Worker from properly capturing it.
 - [`public/mockServiceWorker.js`](public/mockServiceWorker.js) the Service Worker, created by running `npx msw init public`.
+
+### NodeJS
+
+- [`src/setupTests.js`](src/setupTests.js) enables mocking for unit tests via `beforeAll`/`afterAll` hooks.
 

--- a/examples/graphql-react-apollo/src/ApolloClient.js
+++ b/examples/graphql-react-apollo/src/ApolloClient.js
@@ -4,4 +4,8 @@ import ApolloClient from 'apollo-boost'
 // in both application runtime and tests.
 export const client = new ApolloClient({
   uri: 'http://localhost:3000/graphql',
+
+  // Use explicit `window.fetch` so tha outgoing requests
+  // are captured and deferred until the Service Worker is ready.
+  fetch: (...args) => fetch(...args),
 })

--- a/examples/graphql-react-apollo/src/index.js
+++ b/examples/graphql-react-apollo/src/index.js
@@ -6,7 +6,7 @@ import { LoginForm } from './LoginForm'
 
 // Start the mocking conditionally.
 if (process.env.NODE_ENV === 'development') {
-  const { worker } = require('./mocks')
+  const { worker } = require('./mocks/browser')
   worker.start()
 }
 

--- a/examples/graphql-react-apollo/src/mocks/browser.js
+++ b/examples/graphql-react-apollo/src/mocks/browser.js
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw'
+import { handlers } from './handlers'
+
+export const worker = setupWorker(...handlers)

--- a/examples/graphql-react-apollo/src/mocks/handlers.js
+++ b/examples/graphql-react-apollo/src/mocks/handlers.js
@@ -1,4 +1,4 @@
-import { setupWorker, graphql } from 'msw'
+import { graphql } from 'msw'
 
 export const handlers = [
   // Capture a "Login" mutation
@@ -30,5 +30,3 @@ export const handlers = [
     )
   }),
 ]
-
-export const worker = setupWorker(...handlers)

--- a/examples/graphql-react-apollo/src/mocks/server.js
+++ b/examples/graphql-react-apollo/src/mocks/server.js
@@ -1,0 +1,5 @@
+import { setupServer } from 'msw/node'
+import { handlers } from './handlers'
+
+// Setup requests interception using the given handlers.
+export const server = setupServer(...handlers)

--- a/examples/graphql-react-apollo/src/setupTests.js
+++ b/examples/graphql-react-apollo/src/setupTests.js
@@ -3,11 +3,7 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect'
-import { setupServer } from 'msw/node'
-import { handlers } from './mocks'
-
-// Setup requests interception using the given handlers.
-const server = setupServer(...handlers)
+import { server } from './mocks/server'
 
 beforeAll(() => {
   // Enable the mocking in tests.

--- a/examples/rest-react/README.md
+++ b/examples/rest-react/README.md
@@ -41,6 +41,12 @@ $ yarn test:e2e
 ## Key points
 
 - [`src/mocks.js`](src/mocks.js) describes request handlers to use.
+
+### Browser
+
 - [`src/index.js`](src/index.js) conditionally enables mocking in `development` environment.
-- [`src/setupTests.js`](src/setupTests.js) enables mocking for unit tests via `beforeAll`/`afterAll` hooks.
 - [`public/mockServiceWorker.js`](public/mockServiceWorker.js) the Service Worker, created by running `npx msw init public`.
+
+### NodeJS
+
+- [`src/setupTests.js`](src/setupTests.js) enables mocking for unit tests via `beforeAll`/`afterAll` hooks.


### PR DESCRIPTION
## Changes

- Structures the mock definitions to have a recommended folder structure and properly manage browser/server dependencies (spotted with the latest addition of throwing on using worker/server in a wrong environment)
- Adds a custom `fetch` property to the `ApolloClient` instance, to have a proper deferred initial render requests interception

## GitHub

- Fixes #14 