### PR TITLE
add graphql-react-apollo query example

### DIFF
--- a/examples/graphql-react-apollo/src/User.js
+++ b/examples/graphql-react-apollo/src/User.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { useQuery } from '@apollo/react-hooks'
+import { gql } from 'apollo-boost'
+
+const USER_QUERY = gql`
+  query getUser {
+    user {
+      id
+      firstName
+      lastName
+    }
+  }
+`
+
+export const User = () => {
+  const { data, loading, error } = useQuery(USER_QUERY)
+  if (loading) {
+    return <div>loading</div>
+  } else if (error) {
+    return <div>error</div>
+  }
+
+  const { user } = data
+
+  return (
+    <div>
+      <h1>
+        <span data-testid="firstName">{user.firstName}</span>{' '}
+        <span data-testid="lastName">{user.lastName}</span>
+      </h1>
+      <p data-testid="userId">{user.id}</p>
+    </div>
+  )
+}

--- a/examples/graphql-react-apollo/src/index.js
+++ b/examples/graphql-react-apollo/src/index.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom'
 import { ApolloProvider } from '@apollo/react-hooks'
 import { client } from './ApolloClient'
 import { LoginForm } from './LoginForm'
+import { User } from './User'
 
 // Start the mocking conditionally.
 if (process.env.NODE_ENV === 'development') {
@@ -10,10 +11,11 @@ if (process.env.NODE_ENV === 'development') {
   worker.start()
 }
 
+const url = window.location.href
 ReactDOM.render(
   <React.StrictMode>
     <ApolloProvider client={client}>
-      <LoginForm />
+      {url.includes('/user') ? <User /> : <LoginForm />}
     </ApolloProvider>
   </React.StrictMode>,
   document.getElementById('root')

--- a/examples/graphql-react-apollo/src/mocks/handlers.js
+++ b/examples/graphql-react-apollo/src/mocks/handlers.js
@@ -29,4 +29,16 @@ export const handlers = [
       })
     )
   }),
+  graphql.query('getUser', (req, res, ctx) => {
+    return res(
+      ctx.data({
+        user: {
+          __typename: 'User',
+          id: 'f79e82e8-c34a-4dc7-a49e-9fadc0979fda',
+          firstName: 'John',
+          lastName: 'Maverick',
+        },
+      })
+    )
+  }),
 ]


### PR DESCRIPTION
### What
- Adds example of how to mock a query in the `graphql-react-apollo` section

### How to test
- Start the app (`cd examples/graphql-react-apollo && yarn start`)
- http://localhost:3001/user