### PR TITLE
Adds a shell script to use locally packed "msw" package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 node_modules
 *.DS_Store
 __*
+*-error.log
+*-debug.log
+msw-v*
 cypress
+package

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "license": "MIT",
   "scripts": {
     "test": "lerna exec --scope=* --concurrency=1 yarn test",
-    "update": "lerna exec --scope=* --concurrency=1 yarn update"
+    "update": "lerna exec --scope=* --concurrency=1 yarn update",
+    "use-packed-msw": "scripts/use-packed-msw.sh"
   },
   "devDependencies": {
     "lerna": "^3.21.0"

--- a/scripts/use-packed-msw.sh
+++ b/scripts/use-packed-msw.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+tarball_path=$1
+
+echo "Using local tarbal $tarball_path"
+
+# Upack the tarball
+tar zxvf $tarball_path -C $PWD
+
+echo "Successfully unpacked $tarball_path"
+package_path="$PWD/package"
+
+echo "Using unpacked package at $package_path"
+ls -la $package_path
+
+# Install unpacked tarball to all sub-repositories
+echo "Installing local package in the workspace..."
+yarn workspaces run add file:"$package_path" --no-lockfile


### PR DESCRIPTION
## Changes

- Adds a Shell script to use a given tarball of locally packed `msw` and install it to all nested repositories.

## GitHub

- Pre-requisite for https://github.com/mswjs/msw/pull/248