### PR TITLE
Updates the worker file during "use-packed-msw" command

### DIFF
--- a/scripts/use-packed-msw.sh
+++ b/scripts/use-packed-msw.sh
@@ -17,3 +17,6 @@ ls -la $package_path
 # Install unpacked tarball to all sub-repositories
 echo "Installing local package in the workspace..."
 yarn workspaces run add file:"$package_path" --no-lockfile
+
+# Update the "mockServiceWorker.js" in all examples
+yarn update


### PR DESCRIPTION
> Discovered in https://github.com/mswjs/msw/pull/224

## Changes

- After the custom packed `msw` package is unpacked and installed, adds the `yarn update` command that would run `npx msw init <PUBLIC_DIR>` in all examples. This propagates the changes that a local build of `msw` may have made to the `mockServiceWorker.js` file.