### PR TITLE
fix: exclude MSW in angular builds

### DIFF
--- a/examples/rest-angular/src/environments/environment.ts
+++ b/examples/rest-angular/src/environments/environment.ts
@@ -2,8 +2,11 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
+import { worker } from '../mocks/browser';
+worker.start();
+
 export const environment = {
-  production: false
+  production: false,
 };
 
 /*

--- a/examples/rest-angular/src/main.ts
+++ b/examples/rest-angular/src/main.ts
@@ -6,11 +6,8 @@ import { environment } from './environments/environment';
 
 if (environment.production) {
   enableProdMode();
-} else {
-  const { worker } = require('./mocks/browser')
-  worker.start()
 }
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule)
-  .catch(err => console.error(err));
+  .catch((err) => console.error(err));

--- a/examples/rest-angular/tsconfig.app.json
+++ b/examples/rest-angular/tsconfig.app.json
@@ -5,12 +5,6 @@
     "outDir": "./out-tsc/app",
     "types": ["node"]
   },
-  "files": [
-    "src/main.ts",
-    "src/polyfills.ts"
-  ],
-  "include": [
-    "src/**/*.d.ts",
-    "src/mocks/browser.ts",
-  ]
+  "files": ["src/main.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.d.ts"]
 }


### PR DESCRIPTION
## Changes

<!-- Provide a brief description of what these changes are about. -->

Properly exlcudes MSW in an Angular build.
Closes #31

Before: 
![image](https://user-images.githubusercontent.com/28659384/90511504-da10db00-e15c-11ea-9a8e-498fcd897322.png)

After:
![image](https://user-images.githubusercontent.com/28659384/90511683-1cd2b300-e15d-11ea-899c-2b68b2292e66.png)



## Example checklist

<!-- If you are submitting a new example, please go through the checklist below and ensure you pass each listed point. If you are not submitting an example, remove the "Example checklist" section. -->

- [x] **I've followed the [Contribution guidelines](./CONTRIBUTING.md)**.
- [x] I've verified that all added tests pass by running `npm test`.
- [x] I've included only the necessary minimum setup to showcase the example.
- [ ] I've added a `README.md` file to the root directory of my example.
