### PR TITLE
Fixed broken link in graphql-react-apollo README 

### DIFF
--- a/examples/graphql-react-apollo/README.md
+++ b/examples/graphql-react-apollo/README.md
@@ -41,7 +41,7 @@ $ yarn test:e2e
 
 ## Key points
 
-- [`src/mocks.js`](src/mocks.js) describes GraphQL operations to mock.
+- [`src/mocks/handlers.js`](src/mocks/handlers.js) describes GraphQL operations to mock.
 
 ### Browser
 


### PR DESCRIPTION
## Changes

<!-- Provide a brief description of what these changes are about. -->

- The link to src/mocks.js in the KeyPoints section gives a 404. I updated the link to point to src/mocks/handlers.js instead.




