### PR TITLE
add cache clearing to apollo example

### DIFF
--- a/examples/graphql-react-apollo/src/setupTests.js
+++ b/examples/graphql-react-apollo/src/setupTests.js
@@ -3,11 +3,18 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/extend-expect'
+import { client } from './ApolloClient'
 import { server } from './mocks/server'
 
 beforeAll(() => {
   // Enable the mocking in tests.
   server.listen()
+})
+
+beforeEach(() => {
+  // Ensure Apollo cache is cleared between tests.
+  // https://www.apollographql.com/docs/react/api/core/ApolloClient/#ApolloClient.clearStore
+  return client.clearStore()
 })
 
 afterEach(() => {


### PR DESCRIPTION
## Changes

<!-- Provide a brief description of what these changes are about. -->

- Adds cache clearing to `examples/graphql-react-apollo`

This gotcha is called out in the [MSW FAQs](https://mswjs.io/docs/faq#apollo-client) but isn't specifically addressed in the example. This is likely to come up for any non-trivial implementation, so I think it would be helpful to include.
