### PR TITLE
fix: reference username in login mutation (graphql-react-apollo)

### DIFF
--- a/examples/graphql-react-apollo/src/LoginForm.js
+++ b/examples/graphql-react-apollo/src/LoginForm.js
@@ -3,7 +3,7 @@ import { gql, useMutation } from '@apollo/client'
 
 const LOG_IN = gql`
   mutation Login($username: String!) {
-    user {
+    user(username: $username) {
       id
       firstName
       lastName


### PR DESCRIPTION
## Changes

<!-- Provide a brief description of what these changes are about. -->

I was tinkering around in my own toy project while following the graphql-react-apollo example, and apollo/client was just refusing to send the variable from the mutation.

So I found out that if you don't reference a variable that you define, apollo client does not send it. So:

```graphql
mutation Login($username: String!) {
  user {
    id
    firstName
    lastName
  }
}
```

Should be:

```graphql
mutation Login($username: String!) {
  user(username: $username) {
    id
    firstName
    lastName
  }
}
```

But when I tested the project from the fork this issue didn't happen. It turns out that this is a new behavior that doesn't happen in  `"@apollo/client": "3.2.2`, but it does in `"@apollo/client": "^3.7.1"`

However, even though with the current version this works, I think it's still wrong and should be fixed. I imagine that in the future people will be very confused by the example, as I was. So here's the fix, I didn't bump any versions, just the mutation. Let me know if you want me to bump the apollo/client version.