### PR TITLE
fix codesandbox repo url

### DIFF
--- a/examples/with-angular/README.md
+++ b/examples/with-angular/README.md
@@ -2,7 +2,7 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Angular](https://github.com/angular/angular).
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-angular)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-angular)
 
 ## Common
 

--- a/examples/with-jest-jsdom/README.md
+++ b/examples/with-jest-jsdom/README.md
@@ -2,7 +2,7 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Jest](https://github.com/jestjs/jest) and [JSDOM](https://github.com/jsdom/jsdom).
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-jest-jsdom)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-jest-jsdom)
 
 ## General
 

--- a/examples/with-jest/README.md
+++ b/examples/with-jest/README.md
@@ -2,4 +2,4 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Jest](https://github.com/jestjs/jest).
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-jest)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-jest)

--- a/examples/with-karma/README.md
+++ b/examples/with-karma/README.md
@@ -2,7 +2,7 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Karma](https://github.com/karma-runner/karma).
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-karma)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-karma)
 
 ## Key points
 

--- a/examples/with-playwright/README.md
+++ b/examples/with-playwright/README.md
@@ -2,4 +2,4 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Playwright](https://github.com/microsoft/playwright).
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-playwright)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-playwright)

--- a/examples/with-remix/README.md
+++ b/examples/with-remix/README.md
@@ -2,7 +2,7 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Remix](https://github.com/remix-run/remix).
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-remix)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-remix)
 
 ## General
 

--- a/examples/with-svelte/README.md
+++ b/examples/with-svelte/README.md
@@ -2,7 +2,7 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Svelte](https://github.com/sveltejs/svelte).
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-svelte)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-svelte)
 
 ## General
 

--- a/examples/with-vitest-cjs/README.md
+++ b/examples/with-vitest-cjs/README.md
@@ -2,4 +2,4 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Vitest](https://github.com/vitest-dev/vitest) in a CommonJS project.
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-vitest-cjs)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-vitest-cjs)

--- a/examples/with-vitest/README.md
+++ b/examples/with-vitest/README.md
@@ -2,4 +2,4 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Vitest](https://github.com/vitest-dev/vitest).
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-vitest)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-vitest)

--- a/examples/with-vue/README.md
+++ b/examples/with-vue/README.md
@@ -2,7 +2,7 @@
 
 [Mock Service Worker](https://github.com/mswjs/msw) usage example with [Vue](https://github.com/vuejs/).
 
-[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples-new/tree/main/examples/with-vue)
+[![Edit in CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/mswjs/examples/tree/main/examples/with-vue)
 
 ## General
 


### PR DESCRIPTION
Points to the right repository name in CodeSandbox edit links. 