### PR TITLE
add multiple directories to "msw.workerDirectory"

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,15 @@
   "devDependencies": {
     "typescript": "^5.0.4"
   },
-  "packageManager": "pnpm@7.20.0"
+  "packageManager": "pnpm@7.20.0",
+  "msw": {
+    "workerDirectory": [
+      "./examples/with-angular/src",
+      "./examples/with-karma/test",
+      "./examples/with-playwright/app",
+      "./examples/with-remix/public",
+      "./examples/with-svelte/static",
+      "./examples/with-vue/public"
+    ]
+  }
 }


### PR DESCRIPTION
- Closes #108 

This will allow us to update the worker script across all examples that use the browser integration by running `npx msw init` in the root-level of the repo. 