### PR TITLE
chore: update Remix README.md to correct api call

### DIFF
--- a/examples/with-remix/README.md
+++ b/examples/with-remix/README.md
@@ -51,4 +51,4 @@ touch mocks/node.ts
 
 ### 2. Enable mocking
 
-In [`entry.server.tsx`](./app/entry.server.tsx), import the `handlers.ts` and enable mocking by calling `enableApiMocking()` from the `node.ts` setup.
+In [`entry.server.tsx`](./app/entry.server.tsx), import the `handlers.ts` and enable mocking by calling `server.listen()` from the `node.ts` setup.


### PR DESCRIPTION
**Description**

I noticed this mistake in the Remix example when I was going through it.

One should call `server.listen()` not `enableApiMocking()` (perhaps that was the old API)