### PR TITLE
fix: installing deps error: "Invalid package manager specification in package.json; expected a semver version"

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "typescript": "^5.0.4"
   },
-  "packageManager": "pnpm@8.15",
+  "packageManager": "pnpm@8.15.0",
   "msw": {
     "workerDirectory": [
       "./examples/with-angular/src",


### PR DESCRIPTION
Hi! 
I encountered an issue while trying to install dependencies, but this fix resolved it.